### PR TITLE
Adicionado reset do formulário após exibição dos resultados

### DIFF
--- a/codigo/js/filteredSearch.js
+++ b/codigo/js/filteredSearch.js
@@ -80,5 +80,6 @@ searchForm.addEventListener("submit", (event) => {
     });
 
     resultsContainer.innerHTML = html; // Exibe o HTML dos resultados no container
+    searchForm.reset(); // Limpa o formulário
   };
 });


### PR DESCRIPTION
Adicionei a linha com o método "searchForm.reset();" ao final da função "displayResults". Isso irá redefinir todos os campos do formulário para seus valores padrão, limpando assim os campos após a exibição dos resultados.

Essa alteração garante que o formulário seja limpo automaticamente após a exibição dos resultados, melhorando a experiência do usuário.